### PR TITLE
Prevent scrolling out of screen on itch.io

### DIFF
--- a/BookOfShaders.gd
+++ b/BookOfShaders.gd
@@ -27,6 +27,10 @@ func _input(event):
 		# send mouse movement to the shader - even if the shader doesn't have the param
 		$ColorRect.material.set_shader_param('mouse_position', get_local_mouse_position())
 
+func _unhandled_input(event):
+	# Prevent web page scrolling?
+	pass
+
 func _process(delta):
 	update_delta += delta
 	save_delta += delta


### PR DESCRIPTION
When scrolling the within the app https://jayaarrgh.itch.io/book-of-shaders-godot it scrolls out of screen which is annoying.

![godot-shader](https://user-images.githubusercontent.com/371014/108208289-23041500-7129-11eb-9807-341a57349a66.gif)

Not sure this helps but not sure how to test myself.